### PR TITLE
Use 501 instead of 500 as default HTTP code

### DIFF
--- a/app/templates/_handler_express.js
+++ b/app/templates/_handler_express.js
@@ -11,7 +11,7 @@ module.exports = {
      * produces: <%=method.produces && method.produces.join(', ')%>
      */
     <%=method.method%>: function <%=method.name%>(req, res) {
-        res.send(500);
+        res.send(501);
     }<%if (i < methods.length - 1) {%>, <%}%>
     <%})%>
 };

--- a/app/templates/_handler_hapi.js
+++ b/app/templates/_handler_hapi.js
@@ -11,7 +11,7 @@ module.exports = {
      * produces: <%=method.produces && method.produces.join(', ')%>
      */
     <%=method.method%>: function <%=method.name%>(req, reply) {
-        reply().code(500);
+        reply().code(501);
     }<%if (i < methods.length - 1) {%>, <%}%>
     <%})%>
 };


### PR DESCRIPTION
501 is "Not implemented" while 500 is "Internal server error" ([ref](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1)).
"Not implemented" seems more realistic for a stub.
