### PR TITLE
Correct response property

### DIFF
--- a/app/templates/_test_hapi.js
+++ b/app/templates/_test_hapi.js
@@ -76,7 +76,7 @@ Test('api', function (t) {
         <%}%>
         server.inject(options, function (res) {
             t.strictEqual(res.statusCode, <%=responseCode%>, '<%=operation.method.toLowerCase()%> <%=operation.path%> <%=responseCode%> status.');<%if (responseSchema) {%>
-            responseSchema.validate(res.body, function (error) {
+            responseSchema.validate(res.payload, function (error) {
                 t.ok(!error, 'Response schema valid.');
             });<%}%>
             t.end();


### PR DESCRIPTION
`server.inject` response callback exposes the response contents in the `payload` property, as specified in the [Hapi 7.5.x spec](http://hapijs.com/api#serverinjectoptions-callback).
