### PR TITLE
change deprecated res.send(status) to res.sendStatus(status)

### DIFF
--- a/app/templates/_handler_express.js
+++ b/app/templates/_handler_express.js
@@ -11,7 +11,7 @@ module.exports = {
      * produces: <%=method.produces && method.produces.join(', ')%>
      */
     <%=method.method%>: function <%=method.name%>(req, res) {
-        res.send(501);
+        res.sendStatus(501);
     }<%if (i < methods.length - 1) {%>, <%}%>
     <%})%>
 };

--- a/app/templates/server_express.js
+++ b/app/templates/server_express.js
@@ -13,7 +13,7 @@ var server = http.createServer(app);
 app.use(bodyParser.json());
 
 app.get('/api', function (req, res) {
-    res.send(200);
+    res.sendStatus(200);
 });
 
 app.use(swaggerize({


### PR DESCRIPTION
 from express 4 docs: 
res.sendStatus(200); // equivalent to res.status(200).send('OK')