### PR TITLE
fixing broken swaggerize-restify 

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -21,8 +21,8 @@
         "swaggerize-express": "^3.0.0"<%}%><% if (framework === 'hapi') {%>
         "hapi": "^8.0.0",
         "swaggerize-hapi": "^1.0.0-"<%}%><% if (framework === 'restify') {%>
-        "swaggerize-restify": "^1.0.0",
-	"restify": "^2.8.5"<%}%>
+        "swaggerize-restify": "^2.0.0",
+	"restify": "^3.0.3"<%}%>
     },
     "devDependencies": {
         "tape": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "escodegen": "^1.4.1",
     "esprima": "^1.2.2",
     "js-yaml": "^3.2.6",
-    "restify": "^2.8.5",
+    "restify": "^3.0.3",
     "swaggerize-builder": "^2.0.0",
     "swaggerize-express": "^3.0.0",
     "swaggerize-hapi": "^1.0.0-",


### PR DESCRIPTION
Recently merged `swaggerize-restify` app template is actually broken, by bad mistake on my part - `package.json` still specified `swaggerize-restify` 1.0.

Also, good opportunity to update to restify 3.0 - new major version doesn't actually break anything in this case (it's about different order of arguments passed to functions handling server events - https://github.com/restify/node-restify/issues/753 - which are not used here, at all).