### PR TITLE
fix reference to app.setHost

### DIFF
--- a/app/templates/server_express.js
+++ b/app/templates/server_express.js
@@ -18,5 +18,5 @@ app.use(swaggerize({
 }));
 
 server.listen(8000, function () {
-    app.setHost(server.address().address + ':' + server.address().port);
+    app.swagger.api.host = server.address().address + ':' + server.address().port;
 });


### PR DESCRIPTION
I've made a fix to the _server\_express.js_ template, to bring it in line with changes that were part of swaggerize-express 4.0: [https://github.com/krakenjs/swaggerize-express/blob/2cdb0d09600c328dd0648fc3fabd442b8e2e3970/CHANGELOG.md#400](https://github.com/krakenjs/swaggerize-express/blob/2cdb0d09600c328dd0648fc3fabd442b8e2e3970/CHANGELOG.md#400)