### PR TITLE
fix for path bug on Windows (issue #40)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,7 @@
 
 var util = require('util'),
     path = require('path'),
-      fs = require('fs'),
+    fs = require('fs'),
     yeoman = require('yeoman-generator'),
     jsYaml = require('js-yaml'),
     apischema = require('swagger-schema-official/schema'),
@@ -301,9 +301,9 @@ var ModuleGenerator = yeoman.generators.Base.extend({
         api = this.api;
         models = {};
 
-        apiPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'config/' + path.basename(this.apiPath)))).replace(/\\/g,'/');;
+        apiPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'config/' + path.basename(this.apiPath)))).replace(/\\/g,'/');
         modelsPath = (path.join(self.appRoot, 'models')).replace(/\\/g,'/');;
-        handlersPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'handlers'))).replace(/\\/g,'/');;
+        handlersPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'handlers'))).replace(/\\/g,'/');
 
         if (api.definitions && modelsPath) {
 

--- a/app/index.js
+++ b/app/index.js
@@ -302,7 +302,7 @@ var ModuleGenerator = yeoman.generators.Base.extend({
         models = {};
 
         apiPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'config/' + path.basename(this.apiPath)))).replace(/\\/g,'/');
-        modelsPath = (path.join(self.appRoot, 'models')).replace(/\\/g,'/');;
+        modelsPath = (path.join(self.appRoot, 'models')).replace(/\\/g,'/');
         handlersPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'handlers'))).replace(/\\/g,'/');
 
         if (api.definitions && modelsPath) {

--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,7 @@
 
 var util = require('util'),
     path = require('path'),
-	  fs = require('fs'),
+      fs = require('fs'),
     yeoman = require('yeoman-generator'),
     jsYaml = require('js-yaml'),
     apischema = require('swagger-schema-official/schema'),
@@ -157,7 +157,7 @@ var ModuleGenerator = yeoman.generators.Base.extend({
             this.copy('gitignore', '.gitignore');
             this.copy('npmignore', '.npmignore');
 
-            var relativeApiPath = this.apiConfigPath = path.relative(this.appRoot, path.join(this.appRoot, 'config/' + path.basename(this.apiPath)));
+            var relativeApiPath = this.apiConfigPath = (path.relative(this.appRoot, path.join(this.appRoot, 'config/' + path.basename(this.apiPath)))).replace(/\\/g,'/');
 
             this.template('server_' + this.framework + '.js', 'server.js', {
                 apiPath: relativeApiPath
@@ -301,9 +301,9 @@ var ModuleGenerator = yeoman.generators.Base.extend({
         api = this.api;
         models = {};
 
-        apiPath = path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'config/' + path.basename(this.apiPath)));
-        modelsPath = path.join(self.appRoot, 'models');
-        handlersPath = path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'handlers'));
+        apiPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'config/' + path.basename(this.apiPath)))).replace(/\\/g,'/');;
+        modelsPath = (path.join(self.appRoot, 'models')).replace(/\\/g,'/');;
+        handlersPath = (path.relative(path.join(self.appRoot, 'tests'), path.join(self.appRoot, 'handlers'))).replace(/\\/g,'/');;
 
         if (api.definitions && modelsPath) {
 


### PR DESCRIPTION
this fix will solve the problem reported in issue #40 that affects all Windows users, simply replacing all '\' chars with '/' char in all template-generated paths