### PR TITLE
allow for '$ref'd parameters for reusability

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -217,12 +217,28 @@ var ModuleGenerator = yeoman.generators.Base.extend({
                 if (!operation) {
                     return;
                 }
+                var parameters = [];
+                operation.parameters.forEach(function(parameter){
+                  //if it's a reference, it'll be a single object with the $ref property, fetch that from the self.api.parameters by name
+                  if(parameter['$ref']){
+                    //fetch from self.api.parameter by name
+                    var parameterName = parameter['$ref'].split('/')[2];
+                    if(self.api.parameters[parameterName]){
+                      //does param exist in parameters?
+                      parameters.push(self.api.parameters[parameterName]);
+                    }
+                    //if the reference name does not exist in the parameters object of the swagger api doc, then it's malformed and I don't know what to say.
+
+                  } else {
+                    parameters.push(parameter); //otherwise it's a normal parameter - just push it into the array
+                  }
+                })
 
                 route.methods.push({
                     method: verb,
                     name: operation.operationId || '',
                     description: operation.description || '',
-                    parameters: operation.parameters || [],
+                    parameters: parameters || [],
                     produces: operation.produces || []
                 });
 


### PR DESCRIPTION
in a correctly formed swagger api doc (as in, editor.swagger.io doesn't complain at you) you can have reusable parameters - they are 'referenced' by a single object with $ref : '#/parameters/namedParam' this allows for parameter reuse. I've made a change that I believe supports that. please take a look, and thanks for your time! for issue #54 