### PR TITLE
robust truthy checks for parameter schema definitions

### DIFF
--- a/app/templates/_test_express.js
+++ b/app/templates/_test_express.js
@@ -46,7 +46,7 @@ test('api', function (t) {
                         }
                     });
                 }
-                if (param.in === 'body') {
+                if (param.in === 'body' && param.schema && param.schema.$ref) {
                     body = models[param.schema.$ref.slice(param.schema.$ref.lastIndexOf('/') + 1)];
                 }
             });


### PR DESCRIPTION
- More robust check to avoid error like this one reported here - https://github.com/krakenjs/generator-swaggerize/issues/12
