### PR TITLE
Upgrade enjoi version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,7 +29,7 @@
         "js-yaml": "^3.2.6",
         "jshint": "^2.4.1",
         "istanbul": "~0.2.3",
-        "enjoi": "~0.1.16"<% if (framework === 'express') {%> ,
+        "enjoi": "^1.0.2"<% if (framework === 'express') {%> ,
         "supertest": "~0.13.0"<%}%><% if (framework === 'restify') {%> ,
         "supertest": "~0.13.0"<%}%>
     },

--- a/app/templates/_test_express.js
+++ b/app/templates/_test_express.js
@@ -59,7 +59,9 @@ test('api', function (t) {
         var responseSchema = enjoi({<%_.forEach(Object.keys(responseSchema), function (k, i) {%>
             '<%=k%>': <%=JSON.stringify(responseSchema[k])%><%if (i < Object.keys(responseSchema).length - 1) {%>, <%}%><%})%>
         }, {
-          '#': <%if (apiPath.indexOf('.yaml') === apiPath.length - 5 || apiPath.indexOf('.yml') === apiPath.length - 4) {%> jsYaml.load(fs.readFileSync(path.join(__dirname, './<%=apiPath%>'))) <% }else{ %> require(Path.join(__dirname, './<%=apiPath%>')) <% } %>
+                subSchemas: {
+                    '#': <%if (apiPath.indexOf('.yaml') === apiPath.length - 5 || apiPath.indexOf('.yml') === apiPath.length - 4) {%> jsYaml.load(fs.readFileSync(path.join(__dirname, './<%=apiPath%>'))) <% }else{ %> require(Path.join(__dirname, './<%=apiPath%>')) <% } %>
+                }
         });
         <%}%>
 


### PR DESCRIPTION
swaggerize-express@^4 brings in "enjoi": "^1.0.0" 
https://github.com/krakenjs/generator-swaggerize/blob/master/app/templates/_package.json#L21
However the generated app's dev dependency on enjoi is stuck at an older version making the unit test fail.
https://github.com/krakenjs/generator-swaggerize/blob/master/app/templates/_test_express.js#L59
