### PR TITLE
Use swagger-parser module to load api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ npm-debug.log
 .project
 .idea
 .settings
-.iml
+*.iml
 *.sublime-workspace
 *.sublime-project
 

--- a/app/templates/_test_hapi.js
+++ b/app/templates/_test_hapi.js
@@ -56,7 +56,7 @@ Test('api', function (t) {
                     });
                 }
                 if (param.in === 'body') {
-                    body = models[param.schema.$ref.slice(param.schema.$ref.lastIndexOf('/') + 1)];
+                    body = param.schema;
                 }
             });
         }

--- a/app/templates/_test_restify.js
+++ b/app/templates/_test_restify.js
@@ -47,7 +47,7 @@ test('api', function (t) {
                     });
                 }
                 if (param.in === 'body') {
-                    body = models[param.schema.$ref.slice(param.schema.$ref.lastIndexOf('/') + 1)];
+                    body = param.schema;
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
   "dependencies": {
     "enjoi": "^1.0.1",
     "escodegen": "^1.4.1",
+    "esformatter": "^0.9.2",
     "esprima": "^2.7.0",
     "express": "^4.13.3",
     "js-yaml": "^3.2.6",
     "restify": "^3.0.3",
+    "swagger-parser": "^3.4.0",
     "swagger-schema-official": "^2.0.0-",
     "swaggerize-express": "^4.0.0",
     "swaggerize-hapi": "^1.0.0-",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "enjoi": "^1.0.1",
     "escodegen": "^1.4.1",
-    "esformatter": "^0.9.2",
     "esprima": "^2.7.0",
     "express": "^4.13.3",
     "js-yaml": "^3.2.6",


### PR DESCRIPTION
Instead of loading the api file with a generic JSON parse I leveraged the swagger-parse module. This allows for more complex references like referencing definitions in external files.