### PR TITLE
Use empty string for `/` basepath

### DIFF
--- a/lib/routegen.js
+++ b/lib/routegen.js
@@ -9,7 +9,7 @@ module.exports = function routegen (generator, path, pathObj) {
     var mockgenPath = Path.join(generator.dataPath, 'mockgen.js');
     var dataPath = Path.join(generator.dataPath, pathStr + '.js');
     var route = {
-        basePath: generator.api.basePath ? generator.api.basePath : '',
+        basePath: (generator.api.basePath && generator.api.basePath !== '/') ? generator.api.basePath : '',
         path: path,
         apiPathRel: Util.relative(generator.genFilePath, generator.apiConfigPath),
         mockgenPath: Util.relative(generator.genFilePath, generator.destinationPath(mockgenPath)),


### PR DESCRIPTION
- For `basePath` configured as `/`, no need to prefix the path.