### PR TITLE
Unit test - send data for all the methods with body param

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,7 +24,7 @@
 
 work
 build
-test
+./test
 pids
 logs
 results

--- a/generators/app/templates/hapi/server.js
+++ b/generators/app/templates/hapi/server.js
@@ -13,7 +13,7 @@ Server.connection({
 Server.register({
     register: Swaggerize,
     options: {
-        api: Path.resolve('<%=apiPathRel%>.replace(/\\/g,'/')'),
+        api: Path.resolve('<%=apiPathRel.replace(/\\/g,'/')%>'),
         handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')
     }
 }, function () {

--- a/generators/test/templates/express/test.js
+++ b/generators/test/templates/express/test.js
@@ -46,10 +46,7 @@ Test('<%=path%>', function (t) {
                 //Mock request Path templates({}) are resolved using path parameters
                 request = Request(App)
                     .<%=mt%>('<%=basePath%>' + mock.request.path);
-                <%
-                //Send the request body for `post` and `put` operations
-                if (mt === 'post' || mt === 'put') {
-                %>if (mock.request.body) {
+                if (mock.request.body) {
                     //Send the request body
                     request = request.send(mock.request.body);
                 } else if (mock.request.formData){
@@ -57,7 +54,7 @@ Test('<%=path%>', function (t) {
                     request = request.send(mock.request.formData);
                     //Set the Content-Type as application/x-www-form-urlencoded
                     request = request.set('Content-Type', 'application/x-www-form-urlencoded');
-                }<%}%>
+                }
                 // If headers are present, set the headers.
                 if (mock.request.headers && mock.request.headers.length > 0) {
                     Object.keys(mock.request.headers).forEach(function (headerName) {
@@ -76,6 +73,7 @@ Test('<%=path%>', function (t) {
                         response = res.text;
                     }
                     t.ok(validate(response), 'Valid response');
+                    t.error(validate.errors, 'No validation errors');
                     <%}%>t.end();
                 });
             });

--- a/generators/test/templates/hapi/test.js
+++ b/generators/test/templates/hapi/test.js
@@ -53,10 +53,7 @@ Test('<%=path%>', function (t) {
                     method: '<%=mt%>',
                     url: '<%=basePath%>' + mock.request.path
                 };
-                <%
-                //Send the request body for `post` and `put` operations
-                if (mt === 'post' || mt === 'put')
-                {%>if (mock.request.body) {
+                if (mock.request.body) {
                     //Send the request body
                     options.payload = mock.request.body;
                 } else if (mock.request.formData) {
@@ -65,7 +62,7 @@ Test('<%=path%>', function (t) {
                     //Set the Content-Type as application/x-www-form-urlencoded
                     options.headers = options.headers || {};
                     options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-                }<%}%>
+                }
                 // If headers are present, set the headers.
                 if (mock.request.headers && mock.request.headers.length > 0) {
                     options.headers = mock.request.headers;
@@ -77,6 +74,7 @@ Test('<%=path%>', function (t) {
                     %>var Validator = require('is-my-json-valid');
                     var validate = Validator(api.paths['<%=path%>']['<%=operation.method%>']['responses']['<%=operation.response%>']['schema']);
                     t.ok(validate(res.result || res.payload), 'Valid response');
+                    t.error(validate.errors, 'No validation errors');
                     <%}%>t.end();
                 });
             });

--- a/generators/test/templates/restify/test.js
+++ b/generators/test/templates/restify/test.js
@@ -43,10 +43,7 @@ Test('<%=path%>', function (t) {
                 //Mock request Path templates({}) are resolved using path parameters
                 request = Request(server)
                     .<%=mt%>('<%=basePath%>' + mock.request.path);
-                <%
-                //Send the request body for `post` and `put` operations
-                if (mt === 'post' || mt === 'put') {
-                %>if (mock.request.body) {
+                if (mock.request.body) {
                     //Send the request body
                     request = request.send(mock.request.body);
                 } else if (mock.request.formData) {
@@ -54,7 +51,7 @@ Test('<%=path%>', function (t) {
                     request = request.send(mock.request.formData);
                     //Set the Content-Type as application/x-www-form-urlencoded
                     request = request.set('Content-Type', 'application/x-www-form-urlencoded');
-                }<%}%>
+                }
                 // If headers are present, set the headers.
                 if (mock.request.headers && mock.request.headers.length > 0) {
                     Object.keys(mock.request.headers).forEach(function (headerName) {
@@ -73,6 +70,7 @@ Test('<%=path%>', function (t) {
                         response = res.text;
                     }
                     t.ok(validate(response), 'Valid response');
+                    t.error(validate.errors, 'No validation errors');
                     <%}%>t.end();
                 });
             });

--- a/package.json
+++ b/package.json
@@ -55,11 +55,5 @@
     "swagger-parser": "^3.4.1",
     "underscore.string": "^3.3.4",
     "yeoman-generator": "^0.21.2"
-  },
-  "files": [
-    "generators/app",
-    "generators/data",
-    "generators/handler",
-    "generators/test"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-swaggerize",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.4",
   "description": "Yeoman generator for openAPI(swagger) application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-swaggerize",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "Yeoman generator for openAPI(swagger) application",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Send data for all the methods with body param (not just `post` and `put`). Operations like `patch` and `delete` also could define `body` parameter.

- Get rid off the `files` from `package.json` because the project has `.npmignore` to control the file list.