### PR TITLE
security authorize handlers based on securityDefinitions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage
+templates

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you want to generate (or regenerate) only a specific component, you can use `
 - `yo swaggerize:data`
 
 Generates `data` providers based on `paths` and `responses` in swagger api document.
+This also generates the `config/swagger.json` (A copy of the swagger api document file input) and `security` authorize handlers based on `securityDefinitions`.
 
 - `yo swaggerize:handler`
 
@@ -84,8 +85,35 @@ Generates unit `tests` based on `paths`, `parameters` and `responses` in swagger
 
 - `/config` - A copy of the swagger api document file input, will be generated at `/config/swagger.json`.
 - `/data` - Data providers for paths(routes).
-- `/handlers` - Application paths (routes) based on swagger api.
+- `/security` - Authorize handlers for security schemes declared by `securityDefinitions`.
+- `/handlers` - Application paths (routes) based on swagger api `paths`.
 - `/tests` - Unit tests for paths(routes).
+
+Example:
+
+```
+    ├── README.md
+    ├── .eslintrc
+    ├── .gitignore
+    ├── .npmignore
+    ├── config
+    │   └── swagger.json
+    ├── data
+    │   ├── mockgen.js
+    │   └── hellopath
+    │       └── {id}.js
+    ├── handlers
+    │   └── hellopath
+    │       └── {id}.js
+    ├── package.json
+    ├── security
+    │   ├── hello_Oauth2.js
+    │   └── hello_api_key.js
+    ├── server.js
+    └── tests
+        └── hellopath
+            └── {id}.js
+```
 
 ##### Handlers
 
@@ -104,6 +132,10 @@ A data file will be generated corresponding to every a `path` definition of the 
 By default [Response Mock generator](https://github.com/subeeshcbabu/swagmock#responses) is used to provide the data based on the `responses` definition of swagger api.
 Developers should replace these default mock data generators with actual data feeds, based on the functionality.
 
+##### Security authorize handlers
+
+A security authorize handler file will be generated corresponding to the declaration of the security schemes `securityDefinitions`.
+
 ##### Unit tests
 
 A unit test file will be generated corresponding to every a `path` definition of the swagger api (`paths`).
@@ -116,6 +148,7 @@ By default [Request Mock generator](https://github.com/subeeshcbabu/swagmock#req
 - `--apiPath` - specify the path to the swagger document.
 - `--handlerPath` - specify the path to generate the handler files. By default `handlers` directory.
 - `--dataPath` - specify the path to generate the data files. By default `data` directory.
+- `--securityPath` - specify the path to generate the security authorize files. By default `security` directory.
 - `--testPath` - specify the path to generate the unit test files. By default `tests` directory.
 - `--skip-npm-install` - To skip the default `npm install` on the generated project.
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -98,6 +98,7 @@ module.exports = Generators.Base.extend({
                     handlerPath: this.handlerPath,
                     testPath: this.testPath,
                     dataPath: this.dataPath,
+                    securityPath: this.securityPath,
                     framework: this.framework
                 }
             }, {

--- a/generators/app/templates/express/server.js
+++ b/generators/app/templates/express/server.js
@@ -12,7 +12,7 @@ var Server = Http.createServer(App);
 
 App.use(BodyParser.json());
 App.use(BodyParser.urlencoded({
-     "extended": true
+    extended: true
 }));
 
 App.use(Swaggerize({

--- a/generators/app/templates/express/server.js
+++ b/generators/app/templates/express/server.js
@@ -17,7 +17,8 @@ App.use(BodyParser.urlencoded({
 
 App.use(Swaggerize({
     api: Path.resolve('<%=apiPathRel.replace(/\\/g,'/')%>'),
-    handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')
+    handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')<%if (security) {%>,
+    security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
 }));
 
 Server.listen(8000, function () {

--- a/generators/app/templates/hapi/server.js
+++ b/generators/app/templates/hapi/server.js
@@ -14,7 +14,8 @@ Server.register({
     register: Swaggerize,
     options: {
         api: Path.resolve('<%=apiPathRel.replace(/\\/g,'/')%>'),
-        handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')
+        handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')<%if (security) {%>,
+        security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
     }
 }, function () {
     Server.start(function () {

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -23,7 +23,7 @@
         "swagmock": "~0.0.2"
     },
     "devDependencies": {
-        "eslint": "^2",
+        "eslint": "^3",
         "istanbul": "~0.4.3",
         "is-my-json-valid": "^2.13.1",
         "js-yaml": "^3.2.6",

--- a/generators/app/templates/restify/server.js
+++ b/generators/app/templates/restify/server.js
@@ -15,7 +15,8 @@ Server.get('/api', function (req, res) {
 
 Swaggerize(Server, {
     api: Path.resolve('<%=apiPathRel.replace(/\\/g,'/')%>'),
-    handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')
+    handlers: Path.resolve('<%=handlerPath.replace(/\\/g,'/')%>')<%if (security) {%>,
+    security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
 });
 
 Server.listen(8000, function () {

--- a/generators/data/index.js
+++ b/generators/data/index.js
@@ -63,6 +63,27 @@ module.exports = Generators.Base.extend({
                 this.write(this.apiConfigPath, JSON.stringify(this.refApi, null, 4));
             }
         },
+        security: function () {
+            var self = this;
+            var def = this.api.securityDefinitions;
+            var securityPath;
+            if (def && Object.keys(def).length > 0) {
+                //Generate authorize handlers for securityDefinitions
+                Object.keys(def).forEach(function (defName) {
+                    securityPath = Path.join(self.securityPath, defName + '.js');
+                    self.fs.copyTpl(
+                        self.templatePath('security.js'),
+                        self.destinationPath(securityPath),
+                        {
+                            name: defName,
+                            type: def[defName].type,
+                            description: def[defName].description
+                        }
+                    );
+                })
+
+            }
+        },
         mockgen: function () {
             var tmpl = {
                 apiConfigPath: Util.relative(this.destinationPath(this.mockgenPath), this.apiConfigPath)

--- a/generators/data/templates/security.js
+++ b/generators/data/templates/security.js
@@ -1,0 +1,23 @@
+'use strict';
+/**
+ * Authorize function for securityDefinitions:<%=name%>
+ * type : <%=type%>
+ * description: <%=description%>
+ */
+module.exports = function authorize(req, res, next) {
+    //The context('this') for authorize will be bound to the 'securityDefinition'
+    <%if (type === 'oauth2') {
+    %>//this.authorizationUrl - The authorization URL for securityDefinitions:<%=name%>
+    //this.scopes - The available scopes for the securityDefinitions:<%=name%> security scheme
+    //this.flow - The flow used by the securityDefinitions:<%=name%> OAuth2 security scheme
+
+    //req.requiredScopes - list of scope names required for the execution (defined as part of security requirement object).
+    <%} else if (type === 'apiKey') {
+    %>//this.name - The name of the header or query parameter to be used for securityDefinitions:<%=name%> apiKey security scheme.
+    //this.in - The location of the API key ("query" or "header") for securityDefinitions:<%=name%> apiKey security scheme.
+    <%}%>
+
+    //Perform auth here
+
+    next();
+};

--- a/generators/handler/index.js
+++ b/generators/handler/index.js
@@ -70,6 +70,7 @@ module.exports = Generators.Base.extend({
                     refApi: this.refApi,
                     apiPath: this.apiPath,
                     dataPath: this.dataPath,
+                    securityPath: this.securityPath,
                     apiConfigPath: this.apiConfigPath
                 }
             }, {

--- a/generators/test/index.js
+++ b/generators/test/index.js
@@ -76,6 +76,7 @@ module.exports = Generators.Base.extend({
                     handlerPath: this.handlerPath,
                     dataPath: this.dataPath,
                     apiConfigPath: this.apiConfigPath,
+                    securityPath: this.securityPath,
                     framework: this.framework
                 }
             }, {

--- a/generators/test/templates/express/test.js
+++ b/generators/test/templates/express/test.js
@@ -15,7 +15,7 @@ Test('<%=path%>', function (t) {
     var App = Express();
     App.use(BodyParser.json());
     App.use(BodyParser.urlencoded({
-         "extended": true
+        extended: true
     }));
     App.use(Swaggerize({
         api: apiPath,

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -80,6 +80,7 @@ function setDefaults (generator) {
     generator.testPath = generator.options.testPath || '.' + Path.sep + 'tests';
     generator.dataPath = generator.options.dataPath || '.' + Path.sep + 'data';
     generator.mockgenPath = Path.join(generator.dataPath, 'mockgen.js');
+    generator.securityPath = generator.options.securityPath || '.' + Path.sep + 'security';
 }
 
 function startsWith(str, substr) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -81,6 +81,12 @@ function setDefaults (generator) {
     generator.dataPath = generator.options.dataPath || '.' + Path.sep + 'data';
     generator.mockgenPath = Path.join(generator.dataPath, 'mockgen.js');
     generator.securityPath = generator.options.securityPath || '.' + Path.sep + 'security';
+    generator.security = false;
+    if (generator.api
+        && generator.api.securityDefinitions
+        && Object.keys(generator.api.securityDefinitions).length > 0) {
+        generator.security = true;
+    }
 }
 
 function startsWith(str, substr) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js",
-    "lint": "eslint . --ignore-pattern templates",
+    "lint": "eslint .",
     "cover": "istanbul cover tape -- test/*.js"
   },
   "repository": {
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/krakenjs/generator-swaggerize#readme",
   "devDependencies": {
-    "eslint": "^2.11.1",
+    "eslint": "^3",
     "istanbul": "^0.4.3",
     "tape": "^4",
     "yeoman-assert": "^2.2.1",

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -16,7 +16,8 @@ module.exports = {
     options: mockOptions,
     dotFiles: dotFiles,
     projectFiles: projectFiles,
-    routeFiles: buildRouteFiles
+    routeFiles: buildRouteFiles,
+    securityFiles: buildSecurityFiles
 };
 
 function mockPrompt (name) {
@@ -59,8 +60,23 @@ function mockOptions() {
 function buildRouteFiles (prefix, api) {
     api = api || Path.join(__dirname, '../fixture/petstore_no_security.json');
     var apiObj = require(api);
-    var routes = Object.keys(apiObj.paths).map(function (pathStr) {
-        return Path.join(prefix, pathStr.replace(/^\/|\/$/g, '') + '.js');
-    });
+    var routes = [];
+    if (apiObj.paths) {
+        routes = Object.keys(apiObj.paths).map(function (pathStr) {
+            return Path.join(prefix, pathStr.replace(/^\/|\/$/g, '') + '.js');
+        });
+    }
+    return routes;
+}
+
+function buildSecurityFiles (prefix, api) {
+    api = api || Path.join(__dirname, '../fixture/petstore_no_security.json');
+    var apiObj = require(api);
+    var routes = [];
+    if (apiObj.securityDefinitions) {
+        routes = Object.keys(apiObj.securityDefinitions).map(function (pathStr) {
+            return Path.join(prefix, pathStr + '.js');
+        });
+    }
     return routes;
 }

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -57,6 +57,11 @@ function dataTest(tester, options) {
         Assert.file([ options.apiRelPath ]);
         t.end();
     });
+    //Secuirty files
+    tester.test('scaffold data files', function(t) {
+        Assert.file(Util.securityFiles(options.securityPath));
+        t.end();
+    });
 }
 /**
  * Test the generated `handler` files


### PR DESCRIPTION
- generate authorize handlers based on the `securityDefinitions`
- add `security` option for swaggerize init in `server.js`