### PR TITLE
Write the swagger local copy as yaml for yaml file input

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -45,6 +45,7 @@ module.exports = Generators.Base.extend({
             });
             //parse and validate the Swagger API entered by the user.
             if (answers.apiPath) {
+                Util.updateConfigPath(self);
                 Util.validateApi(self, done);
             } else {
                 done();

--- a/generators/handler/index.js
+++ b/generators/handler/index.js
@@ -48,6 +48,7 @@ module.exports = Generators.Base.extend({
             });
             //parse and validate the Swagger API entered by the user.
             if (answers.apiPath) {
+                Util.updateConfigPath(self);
                 Util.validateApi(self, done);
             } else {
                 done();

--- a/generators/test/index.js
+++ b/generators/test/index.js
@@ -51,6 +51,7 @@ module.exports = Generators.Base.extend({
 
             //parse and validate the Swagger API entered by the user.
             if (answers.apiPath) {
+                Util.updateConfigPath(self);
                 Util.validateApi(self, done);
             } else {
                 done();

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -30,7 +30,8 @@ module.exports = {
     operationType: operationType,
     appFramework: appFramework,
     setDefaults: setDefaults,
-    validateApi: validateApi
+    validateApi: validateApi,
+    updateConfigPath: updateConfigPath
 };
 /**
  * Build relative path for module import.
@@ -72,8 +73,7 @@ function setDefaults (generator) {
      * Assume that this.destinationRoot() is the base path and direcory name is the appname default.
      */
     var basePath = generator.destinationRoot();
-    generator.apiPathRel = '.' + Path.sep + 'config' + Path.sep + 'swagger.json';
-    generator.apiConfigPath = generator.options.apiConfigPath || Path.join(generator.destinationPath(), generator.apiPathRel);
+    updateConfigPath(generator);
     generator.appName = Path.basename(basePath);
     generator.framework = generator.options.framework || generator.framework || appFramework(basePath);
     generator.handlerPath = generator.options.handlerPath || '.' + Path.sep + 'handlers';
@@ -87,6 +87,21 @@ function setDefaults (generator) {
         && Object.keys(generator.api.securityDefinitions).length > 0) {
         generator.security = true;
     }
+}
+
+/**
+ * Update the apiConfigPath values based on options or user prompts
+ */
+function updateConfigPath (generator) {
+    var ext = '.json';
+    generator.ymlApi = false;
+    if (generator.apiPath
+        && ('.yml' === Path.extname(generator.apiPath) || '.yaml' === Path.extname(generator.apiPath))) {
+        ext = Path.extname(generator.apiPath);
+        generator.ymlApi = true;
+    }
+    generator.apiPathRel = '.' + Path.sep + 'config' + Path.sep + 'swagger' + ext;
+    generator.apiConfigPath = generator.options.apiConfigPath || Path.join(generator.destinationPath(), generator.apiPathRel);
 }
 
 function startsWith(str, substr) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yeoman-test": "^1.4.0"
   },
   "dependencies": {
+    "js-yaml": "^3.6.1",
     "swagger-parser": "^3.4.1",
     "underscore.string": "^3.3.4",
     "yeoman-generator": "^0.21.2"

--- a/test/app.js
+++ b/test/app.js
@@ -19,7 +19,7 @@ Test('** app generator **', function (t) {
                 t.end();
             });
     });
-
+    
     t.test('scaffold app with options', function (t) {
         var options = {
             framework: 'hapi',
@@ -33,13 +33,26 @@ Test('** app generator **', function (t) {
                 t.end();
             })
             .on('end', function () {
-                var ops = Util.options();
-                //Use loadash merge or Object.assign()
-                ops.framework = options.framework;
-                ops.apiPath = options.apiPath;
-                TestSuite('app')(t, ops);
+                TestSuite('app')(t, Util.options(options));
                 t.end();
             });
     });
 
+    t.test('scaffold app yml file', function (t) {
+        var options = {
+            framework: 'hapi',
+            apiPath: Path.join(__dirname, './fixture/uber.yaml')
+        };
+        Helpers.run(Path.join( __dirname, '../generators/app'))
+            .withOptions(options)
+            .withPrompts(Util.prompt('app'))
+            .on('error', function (error) {
+                t.error(error);
+                t.end();
+            })
+            .on('end', function () {
+                TestSuite('app')(t, Util.options(options));
+                t.end();
+            });
+    });
 });

--- a/test/data.js
+++ b/test/data.js
@@ -23,7 +23,8 @@ Test('** data generator **', function (t) {
     t.test('scaffold data with options', function (t) {
         var options = {
             dataPath: 'mydata',//Custom data path
-            apiPath: Path.join(__dirname, './fixture/petstore.json')
+            apiPath: Path.join(__dirname, './fixture/petstore.json'),
+            securityPath: 'mysecurity'
         };
         Helpers.run(Path.join( __dirname, '../generators/data'))
             .withOptions(options)
@@ -33,13 +34,8 @@ Test('** data generator **', function (t) {
                 t.end();
             })
             .on('end', function () {
-                var ops = Util.options();
-                //Use loadash merge or Object.assign()
-                ops.dataPath = options.dataPath;
-                ops.apiPath = options.apiPath;
-                TestSuite('data')(t, ops);
+                TestSuite('data')(t, Util.options(options));
                 t.end();
             });
     });
-
 });

--- a/test/fixture/uber.yaml
+++ b/test/fixture/uber.yaml
@@ -1,0 +1,284 @@
+swagger: '2.0'
+info:
+  title: Uber API
+  description: Move your app forward with the Uber API
+  version: 1.0.0
+host: api.uber.com
+schemes:
+  - https
+basePath: /v1
+produces:
+  - application/json
+paths:
+  /products:
+    get:
+      summary: Product Types
+      description: |
+        The Products endpoint returns information about the *Uber* products
+        offered at a given location. The response includes the display name
+        and other details about each product, and lists the products in the
+        proper display order.
+      parameters:
+        - name: latitude
+          in: query
+          description: Latitude component of location.
+          required: true
+          type: number
+          format: double
+        - name: longitude
+          in: query
+          description: Longitude component of location.
+          required: true
+          type: number
+          format: double
+      tags:
+        - Products
+      responses:
+        '200':
+          description: An array of products
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Product'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /estimates/price:
+    get:
+      summary: Price Estimates
+      description: >
+        The Price Estimates endpoint returns an estimated price range
+
+        for each product offered at a given location. The price estimate is
+
+        provided as a formatted string with the full price range and the
+        localized
+
+        currency symbol.<br><br>The response also includes low and high
+        estimates,
+
+        and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code
+        for
+
+        situations requiring currency conversion. When surge is active for
+        a particular
+
+        product, its surge_multiplier will be greater than 1, but the price
+        estimate
+
+        already factors in this multiplier.
+      parameters:
+        - name: start_latitude
+          in: query
+          description: Latitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: start_longitude
+          in: query
+          description: Longitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: end_latitude
+          in: query
+          description: Latitude component of end location.
+          required: true
+          type: number
+          format: double
+        - name: end_longitude
+          in: query
+          description: Longitude component of end location.
+          required: true
+          type: number
+          format: double
+      tags:
+        - Estimates
+      responses:
+        '200':
+          description: An array of price estimates by product
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PriceEstimate'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /estimates/time:
+    get:
+      summary: Time Estimates
+      description: 'The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.'
+      parameters:
+        - name: start_latitude
+          in: query
+          description: Latitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: start_longitude
+          in: query
+          description: Longitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: customer_uuid
+          in: query
+          type: string
+          format: uuid
+          description: Unique customer identifier to be used for experience customization.
+        - name: product_id
+          in: query
+          type: string
+          description: 'Unique identifier representing a specific product for a given latitude & longitude.'
+      tags:
+        - Estimates
+      responses:
+        '200':
+          description: An array of products
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Product'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /me:
+    get:
+      summary: User Profile
+      description: The User Profile endpoint returns information about the Uber user that has authorized with the application.
+      tags:
+        - User
+      responses:
+        '200':
+          description: Profile information for a user
+          schema:
+            $ref: '#/definitions/Profile'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /history:
+    get:
+      summary: User Activity
+      description: "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary."
+      parameters:
+        - name: offset
+          in: query
+          type: integer
+          format: int32
+          description: Offset the list of returned results by this amount. Default is zero.
+        - name: limit
+          in: query
+          type: integer
+          format: int32
+          description: 'Number of items to retrieve. Default is 5, maximum is 100.'
+      tags:
+        - User
+      responses:
+        '200':
+          description: History information for the given user
+          schema:
+            $ref: '#/definitions/Activities'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Product:
+    type: object
+    properties:
+      product_id:
+        type: string
+        description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
+      description:
+        type: string
+        description: Description of product.
+      display_name:
+        type: string
+        description: Display name of product.
+      capacity:
+        type: string
+        description: 'Capacity of product. For example, 4 people.'
+      image:
+        type: string
+        description: Image URL representing the product.
+  PriceEstimate:
+    type: object
+    properties:
+      product_id:
+        type: string
+        description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles'
+      currency_code:
+        type: string
+        description: '[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.'
+      display_name:
+        type: string
+        description: Display name of product.
+      estimate:
+        type: string
+        description: 'Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.'
+      low_estimate:
+        type: number
+        description: Lower bound of the estimated price.
+      high_estimate:
+        type: number
+        description: Upper bound of the estimated price.
+      surge_multiplier:
+        type: number
+        description: Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
+  Profile:
+    type: object
+    properties:
+      first_name:
+        type: string
+        description: First name of the Uber user.
+      last_name:
+        type: string
+        description: Last name of the Uber user.
+      email:
+        type: string
+        description: Email address of the Uber user
+      picture:
+        type: string
+        description: Image URL of the Uber user.
+      promo_code:
+        type: string
+        description: Promo code of the Uber user.
+  Activity:
+    type: object
+    properties:
+      uuid:
+        type: string
+        description: Unique identifier for the activity
+  Activities:
+    type: object
+    properties:
+      offset:
+        type: integer
+        format: int32
+        description: Position in pagination.
+      limit:
+        type: integer
+        format: int32
+        description: Number of items to retrieve (100 max).
+      count:
+        type: integer
+        format: int32
+        description: Total number of items available.
+      history:
+        type: array
+        items:
+          $ref: '#/definitions/Activity'
+  Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string

--- a/test/handler.js
+++ b/test/handler.js
@@ -19,7 +19,7 @@ Test('** handler generator **', function (t) {
                 t.end();
             });
     });
-
+    
     t.test('scaffold handler with options', function (t) {
         var options = {
             handlerPath: 'myhandler',//Custom handler path
@@ -33,13 +33,8 @@ Test('** handler generator **', function (t) {
                 t.end();
             })
             .on('end', function () {
-                var ops = Util.options();
-                //Use loadash merge or Object.assign()
-                ops.handlerPath = options.handlerPath;
-                ops.apiPath = options.apiPath;
-                TestSuite('handler')(t, ops);
+                TestSuite('handler')(t, Util.options(options));
                 t.end();
             });
     });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -23,7 +23,8 @@ Test('** test generator **', function (t) {
     t.test('scaffold test files - with options', function (t) {
         var options = {
             testPath: 'mytest',//Custom test path
-            apiPath: Path.join(__dirname, './fixture/petstore.json')
+            apiPath: Path.join(__dirname, './fixture/uber.yaml'),
+            framework: 'restify'
         };
         Helpers.run(Path.join( __dirname, '../generators/test'))
             .withOptions(options)
@@ -33,11 +34,7 @@ Test('** test generator **', function (t) {
                 t.end();
             })
             .on('end', function () {
-                var ops = Util.options();
-                //Use loadash merge or Object.assign()
-                ops.testPath = options.testPath;
-                ops.apiPath = options.apiPath;
-                TestSuite('test')(t, ops);
+                TestSuite('test')(t, Util.options(options));
                 t.end();
             });
     });

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -42,7 +42,7 @@ module.exports = function (generator) {
  */
 function dataTest(tester, options) {
     //Data files
-    var routeFiles = Util.routeFiles(options.dataPath);
+    var routeFiles = Util.routeFiles(options.dataPath, options.apiPath);
     tester.test('scaffold data files', function(t) {
         Assert.file(routeFiles);
         t.end();
@@ -59,7 +59,7 @@ function dataTest(tester, options) {
     });
     //Secuirty files
     tester.test('scaffold data files', function(t) {
-        Assert.file(Util.securityFiles(options.securityPath));
+        Assert.file(Util.securityFiles(options.securityPath, options.apiPath));
         t.end();
     });
 }
@@ -69,7 +69,7 @@ function dataTest(tester, options) {
 function handlerTest(tester, options) {
     //Data files
     tester.test('scaffold handler files', function(t) {
-        Assert.file(Util.routeFiles(options.handlerPath));
+        Assert.file(Util.routeFiles(options.handlerPath, options.apiPath));
         t.end();
     });
 }
@@ -79,7 +79,7 @@ function handlerTest(tester, options) {
 function testTest(tester, options) {
     //Data files
     tester.test('scaffold test files', function(t) {
-        Assert.file(Util.routeFiles(options.testPath));
+        Assert.file(Util.routeFiles(options.testPath, options.apiPath));
         t.end();
     });
 }


### PR DESCRIPTION
- Use `js-yaml` to dump the swagger file in `yaml` format.
- Update tests to use `yaml` examples
