### PR TITLE
security option for the unit test code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add `security` option by default to the unit test files generated for all the frameworks.
+
 # v3.0.0
 
 ## Breaking changes

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -100,7 +100,8 @@ module.exports = Generators.Base.extend({
                     testPath: this.testPath,
                     dataPath: this.dataPath,
                     securityPath: this.securityPath,
-                    framework: this.framework
+                    framework: this.framework,
+                    securith: this.security
                 }
             }, {
                 local: require.resolve('../test')

--- a/generators/test/templates/express/test.js
+++ b/generators/test/templates/express/test.js
@@ -20,7 +20,7 @@ Test('<%=path%>', function (t) {
     App.use(Swaggerize({
         api: apiPath,
         handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
-        security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
+        security: Path.resolve(__dirname, '<%=securityPath.replace(/\\/g,'/')%>')<%}%>
     }));
     Parser.validate(apiPath, function (err, api) {
         t.error(err, 'No parse error');

--- a/generators/test/templates/express/test.js
+++ b/generators/test/templates/express/test.js
@@ -19,7 +19,8 @@ Test('<%=path%>', function (t) {
     }));
     App.use(Swaggerize({
         api: apiPath,
-        handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')
+        handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
+        security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
     }));
     Parser.validate(apiPath, function (err, api) {
         t.error(err, 'No parse error');

--- a/generators/test/templates/hapi/test.js
+++ b/generators/test/templates/hapi/test.js
@@ -23,7 +23,8 @@ Test('<%=path%>', function (t) {
                 register: Swaggerize,
                 options: {
                     api: apiPath,
-                    handlers: Path.join(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')
+                    handlers: Path.join(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
+                    security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
                 }
             }, function (err) {
                 t.error(err, 'No error.');

--- a/generators/test/templates/hapi/test.js
+++ b/generators/test/templates/hapi/test.js
@@ -24,7 +24,7 @@ Test('<%=path%>', function (t) {
                 options: {
                     api: apiPath,
                     handlers: Path.join(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
-                    security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
+                    security: Path.resolve(__dirname, '<%=securityPath.replace(/\\/g,'/')%>')<%}%>
                 }
             }, function (err) {
                 t.error(err, 'No error.');

--- a/generators/test/templates/restify/test.js
+++ b/generators/test/templates/restify/test.js
@@ -17,7 +17,7 @@ Test('<%=path%>', function (t) {
     Swaggerize(server, {
         api: apiPath,
         handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
-        security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
+        security: Path.resolve(__dirname, '<%=securityPath.replace(/\\/g,'/')%>')<%}%>
     });
     Parser.validate(apiPath, function (err, api) {
         t.error(err, 'No parse error');

--- a/generators/test/templates/restify/test.js
+++ b/generators/test/templates/restify/test.js
@@ -16,7 +16,8 @@ Test('<%=path%>', function (t) {
     server.use(Restify.queryParser());
     Swaggerize(server, {
         api: apiPath,
-        handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')
+        handlers: Path.resolve(__dirname, '<%=handlerDir.replace(/\\/g,'/')%>')<%if (security) {%>,
+        security: Path.resolve('<%=securityPath.replace(/\\/g,'/')%>')<%}%>
     });
     Parser.validate(apiPath, function (err, api) {
         t.error(err, 'No parse error');

--- a/lib/routegen.js
+++ b/lib/routegen.js
@@ -15,7 +15,9 @@ module.exports = function routegen (generator, path, pathObj) {
         mockgenPath: Util.relative(generator.genFilePath, generator.destinationPath(mockgenPath)),
         dataPath: Util.relative(generator.genFilePath, generator.destinationPath(dataPath)),
         handlerDir: Util.relative(generator.genFilePath, generator.destinationPath(generator.handlerPath)),
-        operations: []
+        operations: [],
+        security: generator.security,
+        securityPath: Util.relative(generator.genFilePath, generator.destinationPath(generator.securityPath))
     };
 
     Object.keys(pathObj).forEach(function (method) {

--- a/test/app.js
+++ b/test/app.js
@@ -19,7 +19,7 @@ Test('** app generator **', function (t) {
                 t.end();
             });
     });
-    
+
     t.test('scaffold app with options', function (t) {
         var options = {
             framework: 'hapi',
@@ -33,7 +33,7 @@ Test('** app generator **', function (t) {
                 t.end();
             })
             .on('end', function () {
-                TestSuite('app')(t, Util.options(options));
+                TestSuite('app')(t, Util.options(options), true);
                 t.end();
             });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -39,4 +39,23 @@ Test('** test generator **', function (t) {
             });
     });
 
+    t.test('scaffold test files - with security handler', function (t) {
+        var options = {
+            testPath: 'mytest',//Custom test path
+            apiPath: Path.join(__dirname, './fixture/petstore.json'),
+            framework: 'hapi'
+        };
+        Helpers.run(Path.join( __dirname, '../generators/test'))
+            .withOptions(options)
+            .withPrompts(Util.prompt('test'))
+            .on('error', function (error) {
+                t.error(error);
+                t.end();
+            })
+            .on('end', function () {
+                TestSuite('test')(t, Util.options(options), true);
+                t.end();
+            });
+    });
+
 });

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -42,7 +42,7 @@ function mockPrompt (name) {
             apiPath: Path.join(__dirname, '../fixture/petstore_no_security.json')
         },
         test: {
-            framework: 'restify',
+            framework: 'express',
             apiPath: Path.join(__dirname, '../fixture/petstore_no_security.json')
         }
     };

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -52,7 +52,7 @@ function mockPrompt (name) {
 function mockOptions(options) {
     var apiRelPath = './config/swagger.json';
     options = options || {};
-    if ('.yml' === Path.extname(options.apiPath) || '.yaml' === Path.extname(options.apiPath)) {
+    if (options.apiPath && ('.yml' === Path.extname(options.apiPath) || '.yaml' === Path.extname(options.apiPath))) {
         apiRelPath = './config/swagger.yaml';
     }
     return {

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -78,8 +78,19 @@ function handlerTest(tester, options) {
  */
 function testTest(tester, options) {
     //Data files
+    var testFiles = Util.routeFiles(options.testPath, options.apiPath);
     tester.test('scaffold test files', function(t) {
-        Assert.file(Util.routeFiles(options.testPath, options.apiPath));
+        Assert.file(testFiles);
+        t.end();
+    });
+    // Test file content
+    tester.test('test unitetst file content', function(t) {
+        var testFile = testFiles[0];
+        Assert.fileContent([
+            [testFile, new RegExp(options.framework, 'i')],
+            [testFile, new RegExp('swaggerize-' + options.framework, 'i')],
+            [testFile, new RegExp(options.handlerPath, 'i')]
+        ]);
         t.end();
     });
 }

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -25,11 +25,11 @@ module.exports = function (generator) {
             handlerTest(t, options);
             testTest(t, options);
         },
-        app : function (t, options) {
+        app : function (t, options, security) {
             /**
              * Test the generated `app`, `test`, `handler` and `data` files
              */
-            appTest(t, options);
+            appTest(t, options, security);
             dataTest(t, options);
             handlerTest(t, options);
             testTest(t, options);
@@ -86,7 +86,7 @@ function testTest(tester, options) {
 /**
  * Test the generated `app` files - `package.json`, `README.md` etc
  */
-function appTest(tester, options) {
+function appTest(tester, options, security) {
     //Dot files
     tester.test('scaffold dot files', function(t) {
         Assert.file(Util.dotFiles);
@@ -109,4 +109,22 @@ function appTest(tester, options) {
         ]);
         t.end();
     });
+    // Server file content
+    tester.test('test server.js file content', function(t) {
+        Assert.fileContent([
+            ['server.js', new RegExp(options.framework, 'i')],
+            ['server.js', new RegExp('swaggerize-' + options.framework, 'i')],
+            ['server.js', new RegExp(options.handlerPath, 'i')]
+        ]);
+        t.end();
+    });
+    //If security is set to true test the securityPath
+    if (security) {
+        tester.test('test security path', function(t) {
+            Assert.fileContent([
+                ['server.js', new RegExp(options.securityPath, 'i')]
+            ]);
+            t.end();
+        });
+    }
 }

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -17,13 +17,13 @@ module.exports = function (generator) {
             dataTest(t, options);
             handlerTest(t, options);
         },
-        test : function (t, options) {
+        test : function (t, options, secuirty) {
             /**
              * Test the generated `test`, `handler` and `data` files
              */
             dataTest(t, options);
             handlerTest(t, options);
-            testTest(t, options);
+            testTest(t, options, secuirty);
         },
         app : function (t, options, security) {
             /**
@@ -76,16 +76,16 @@ function handlerTest(tester, options) {
 /**
  * Test the generated `test` files
  */
-function testTest(tester, options) {
+function testTest(tester, options, security) {
     //Data files
     var testFiles = Util.routeFiles(options.testPath, options.apiPath);
+    var testFile = testFiles[0];
     tester.test('scaffold test files', function(t) {
         Assert.file(testFiles);
         t.end();
     });
     // Test file content
     tester.test('test unitetst file content', function(t) {
-        var testFile = testFiles[0];
         Assert.fileContent([
             [testFile, new RegExp(options.framework, 'i')],
             [testFile, new RegExp('swaggerize-' + options.framework, 'i')],
@@ -93,6 +93,15 @@ function testTest(tester, options) {
         ]);
         t.end();
     });
+    //If security is set to true test the securityPath
+    if (security) {
+        tester.test('test security path', function(t) {
+            Assert.fileContent([
+                [testFile, new RegExp(options.securityPath, 'i')]
+            ]);
+            t.end();
+        });
+    }
 }
 /**
  * Test the generated `app` files - `package.json`, `README.md` etc


### PR DESCRIPTION
- Add `security` option by default to the unit test files generated for all the frameworks.
