### PR TITLE
Add generator swaggerize version to the generated app for meta details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add the useful meta information, generator version, to the generated app's package.json.
 - Add `security` option by default to the unit test files generated for all the frameworks.
 
 # v3.0.0

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -37,5 +37,8 @@
         "lint": "eslint .",
         "regenerate": "yo swaggerize:test --framework <%=framework%> --apiPath '<%=apiPathRel.replace(/\\/g,'/')%>'"
     },
+    "generator-swaggerize": {
+        "version": "<%=generatorVersion%>"
+    },
     "main": "./server"
 }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2,6 +2,7 @@
 var Path = require('path');
 var Fs = require('fs');
 var Parser = require('swagger-parser');
+var Pkg = require('../../package.json');
 /**
  * List of supported frameworks
  */
@@ -87,6 +88,7 @@ function setDefaults (generator) {
         && Object.keys(generator.api.securityDefinitions).length > 0) {
         generator.security = true;
     }
+    generator.generatorVersion = Pkg.version;
 }
 
 /**

--- a/test/util/testsuite.js
+++ b/test/util/testsuite.js
@@ -120,12 +120,13 @@ function appTest(tester, options, security) {
     //Package content
     tester.test('test package file content', function(t) {
         Assert.fileContent([
-           ['package.json', new RegExp(/\"name\"\: \"mockapp\"/)],
-           ['package.json', new RegExp(/\"author\"\: \"lorem ipsum <loremipsum@awesome\.com>\"/)],
-           ['package.json', new RegExp(/\"url\"\: \"git\:\/\/github\.com\/loremipsum\/mockapp\.git\"/)],
-           ['package.json', new RegExp('\"' + options.framework + '\"\:')],
-           ['package.json', new RegExp('--framework ' + options.framework+ ' --apiPath \'' + options.apiRelPath.replace(/\\/g,'/') + '\'')],
-           ['README.md', new RegExp(/# mockapp/)]
+            ['package.json', new RegExp(/\"generator-swaggerize\"/)],
+            ['package.json', new RegExp(/\"name\"\: \"mockapp\"/)],
+            ['package.json', new RegExp(/\"author\"\: \"lorem ipsum <loremipsum@awesome\.com>\"/)],
+            ['package.json', new RegExp(/\"url\"\: \"git\:\/\/github\.com\/loremipsum\/mockapp\.git\"/)],
+            ['package.json', new RegExp('\"' + options.framework + '\"\:')],
+            ['package.json', new RegExp('--framework ' + options.framework+ ' --apiPath \'' + options.apiRelPath.replace(/\\/g,'/') + '\'')],
+            ['README.md', new RegExp(/# mockapp/)]
         ]);
         t.end();
     });


### PR DESCRIPTION
- Add the useful meta information, generator version, to the generated app's `package.json`. This will help debugging easier if we can readily find out the version of generator is being used.