### PR TITLE
Use cors to avoid options issue and use the later version of swag mock

### DIFF
--- a/generators/app/templates/express/server.js
+++ b/generators/app/templates/express/server.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var App = Express();
 
 var Server = Http.createServer(App);
-
+App.use(cors())
 App.use(BodyParser.json());
 App.use(BodyParser.urlencoded({
     extended: true

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -21,7 +21,8 @@
         "hapi-openapi": "^1.0.0"<%}%><% if (framework === 'restify') {%>
         "swaggerize-restify": "^2.0.0",
         "restify": "^3.0.3"<%}%><% if (framework !== 'hapi') {%>,
-        "swagmock": "~0.0.2"<%}%>
+        "cors":"^2.8.5",
+        "swagmock": "^1.0.0"<%}%>
     },
     "devDependencies": {
         "eslint": "^2",


### PR DESCRIPTION
Use cors to avoid options issue and use the later version of swag mock